### PR TITLE
Add build scripts and documentation for Spice-GTK on macOS arm64

### DIFF
--- a/build-scripts/README.md
+++ b/build-scripts/README.md
@@ -1,0 +1,86 @@
+# Spice-GTK Build Scripts for macOS arm64
+
+This directory contains scripts to build Spice-GTK on macOS arm64.
+
+## Prerequisites
+
+- macOS 12.0 or later
+- Xcode Command Line Tools
+- Homebrew
+- Python 3.11.9 (recommended, managed by pyenv)
+
+## Dependencies
+
+```bash
+# Install build tools
+xcode-select --install
+
+# Install Homebrew if not installed
+/bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/HEAD/install.sh)"
+
+# Install dependencies
+brew install meson ninja pkg-config glib json-glib gstreamer gst-plugins-base gst-plugins-good \
+             gst-plugins-bad gst-libav cairo gtk+3 gtk-doc openssl@3 jpeg-turbo opus \
+             gobject-introspection
+
+# Install pyenv and Python (recommended)
+brew install pyenv
+pyenv install 3.11.9
+pyenv virtualenv 3.11.9 spice-env
+pyenv activate spice-env
+pip install --upgrade pip PyGObject
+```
+
+## Building Spice-GTK
+
+1. Clone this repository:
+   ```bash
+   git clone <repository-url>
+   cd spice/build-scripts
+   ```
+
+2. Run the build script:
+   ```bash
+   ./build-spice-gtk.sh
+   ```
+
+   This will:
+   - Download Spice-GTK 0.42 source
+   - Apply necessary patches for macOS arm64
+   - Build and install to /usr/local
+
+## Verifying the Installation
+
+Run the test script to verify the installation:
+
+```bash
+python3 test_spice.py
+```
+
+## Troubleshooting
+
+### Python Bindings
+
+If you encounter issues with Python bindings, ensure that:
+
+1. The GObject-Introspection typelib files are in your `GI_TYPELIB_PATH`:
+   ```bash
+   export GI_TYPELIB_PATH="/usr/local/lib/girepository-1.0:$GI_TYPELIB_PATH"
+   ```
+
+2. The library path is set correctly:
+   ```bash
+   export DYLD_LIBRARY_PATH="/usr/local/lib:$DYLD_LIBRARY_PATH"
+   ```
+
+### Build Issues
+
+If the build fails due to missing dependencies, ensure all required packages are installed:
+
+```bash
+brew install <missing-package>
+```
+
+## License
+
+This project is licensed under the LGPL-2.1 license.

--- a/build-scripts/build-spice-gtk.sh
+++ b/build-scripts/build-spice-gtk.sh
@@ -1,0 +1,50 @@
+#!/bin/bash
+
+set -e
+
+# Configuration
+SPICE_GTK_VERSION="0.42"
+INSTALL_PREFIX="/usr/local"
+BUILD_DIR="$(pwd)/spice-gtk-${SPICE_GTK_VERSION}-build"
+SOURCE_DIR="$(pwd)/spice-gtk-${SPICE_GTK_VERSION}"
+
+# Create build directory
+mkdir -p "${BUILD_DIR}"
+
+# Clone source if not already present
+if [ ! -d "${SOURCE_DIR}" ]; then
+    git clone --depth 1 --branch "v${SPICE_GTK_VERSION}" \
+        https://gitlab.freedesktop.org/spice/spice-gtk.git "${SOURCE_DIR}"
+    
+    # Apply patches
+    cd "${SOURCE_DIR}"
+    patch -p1 < "../macos-spice-gtk-fixes.patch"
+fi
+
+# Configure build
+cd "${BUILD_DIR}"
+meson setup "${SOURCE_DIR}" \
+    --prefix="${INSTALL_PREFIX}" \
+    --buildtype=release \
+    -Dgtk=enabled \
+    -Dvapi=true \
+    -Dpolkit=disabled \
+    -Dsmartcard=disabled \
+    -Dusbredir=disabled \
+    -Dintrospection=enabled \
+    -Dgtk_doc=disabled \
+    -Dvapi=true \
+    -Dopus=enabled \
+    -Dlz4=disabled \
+    -Dgtk_doc=disabled
+
+# Build
+ninja
+
+# Install
+sudo ninja install
+
+# Update dynamic linker cache
+sudo ldconfig
+
+echo "Spice-GTK ${SPICE_GTK_VERSION} has been successfully installed to ${INSTALL_PREFIX}"

--- a/build-scripts/macos-spice-gtk-fixes.patch
+++ b/build-scripts/macos-spice-gtk-fixes.patch
@@ -1,0 +1,51 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Your Name <your.email@example.com>
+Date: Sat, 3 Aug 2024 17:42:00 +0200
+Subject: [PATCH] Fix macOS arm64 build
+
+- Add custom macOS linker script for symbol exports
+- Update meson.build to use correct linker flags for macOS
+- Fix symbol export issues on macOS
+---
+ src/meson.build | 14 ++++++++++++++
+ macos-link.ld  |  3 +++
+ 2 files changed, 17 insertions(+)
+ create mode 100644 macos-link.ld
+
+diff --git a/src/meson.build b/src/meson.build
+index abc1234..def5678 100644
+--- a/src/meson.build
++++ b/src/meson.build
+@@ -177,6 +177,20 @@ if host_machine.system() == 'windows'
+   spice_client_glib_win_rc = configure_file(input: 'spice-client-glib.rc.in',
+                                           output: 'spice-client-glib.rc',
+                                           configuration: rc_conf)
++elif host_machine.system() == 'darwin'
++  # macOS specific linker flags
++  macos_linker_script = files('../macos-link.ld')
++  spice_client_glib_link_args = [
++    '-Wl,-exported_symbols_list,@0@'.format(meson.current_source_dir() / 'spice-glib-sym-file'),
++    '-Wl,-undefined,error',
++  ]
++  spice_client_glib_deps += [
++    cc.find_library('objc'),
++    dependency('appleframeworks', modules: ['Cocoa', 'IOKit', 'CoreVideo']),
++  ]
++  spice_client_glib_sources += [
++    'osx-io.m',
++  ]
+ endif
+ 
+ # spice-client-glib
+
+diff --git a/macos-link.ld b/macos-link.ld
+new file mode 100644
+index 0000000..abc1234
+--- /dev/null
++++ b/macos-link.ld
+@@ -0,0 +1,3 @@
++{
++  global: _spice_*; _spice_*_get_type; _spice_*_class_*;
++};
+-- 
+2.39.2 (Apple Git-143)

--- a/build-scripts/test_spice.py
+++ b/build-scripts/test_spice.py
@@ -1,0 +1,26 @@
+#!/usr/bin/env python3
+
+import gi
+gi.require_version('Gtk', '3.0')
+gi.require_version('SpiceClientGtk', '3.0')
+from gi.repository import Gtk, SpiceClientGtk
+
+def main():
+    print("Testing Spice-GTK installation...")
+    
+    # Test basic Gtk functionality
+    win = Gtk.Window(title="Spice-GTK Test")
+    win.connect("destroy", Gtk.main_quit)
+    
+    # Test Spice-GTK
+    try:
+        display = SpiceClientGtk.Display()
+        print("✓ SpiceClientGtk.Display initialized successfully")
+    except Exception as e:
+        print(f"✗ Failed to initialize SpiceClientGtk.Display: {e}")
+    
+    win.show_all()
+    Gtk.main()
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
- Added build-spice-gtk.sh script for automated builds
- Added test_spice.py for verification
- Added comprehensive README with build instructions
- Added macOS-specific patches for Spice-GTK